### PR TITLE
Escape error immediately before putting in html

### DIFF
--- a/main.py
+++ b/main.py
@@ -84,7 +84,13 @@ class Index(webapp2.RequestHandler):
 
         # if we have an error, make a <p> to display it
         error = self.request.get("error")
-        error_element = "<p class='error'>" + error + "</p>" if error else ""
+        if error:
+            error_element = (
+                '<p class="error">' +
+                cgi.escape(error, quote=True) +
+                '</p>')
+        else:
+            error_element = ''
 
         # combine all the pieces to build the content of our response
         main_content = edit_header + add_form + crossoff_form + error_element
@@ -123,10 +129,9 @@ class CrossOffMovie(webapp2.RequestHandler):
 
             # make a helpful error message
             error = "'{0}' is not in your Watchlist, so you can't cross it off!".format(crossed_off_movie)
-            error_escaped = cgi.escape(error, quote=True)
 
             # redirect to homepage, and include error as a query parameter in the URL
-            self.redirect("/?error=" + error_escaped)
+            self.redirect("/?error=" + error)
 
         # if we didn't redirect by now, then all is well
         crossed_off_movie_element = "<strike>" + crossed_off_movie + "</strike>"


### PR DESCRIPTION
Previously, we were using cgi.escape to convert html entities
into &lt;, &gt;, etc before sending the error message as a query
param. However, This causes a problem when the error message
contains *any* html entity.

Consider an error like: `"'The <head> and the Heart' is not in your
watchlist"`. cgi.escape'ing this produces `"'The &lt;head&gt; and the
Heart' is not in your watchlist"`. Trying to pass that as a query
parameter looks like:

    ?error=%27The%20&lt;...

The value of 'error' will only be "'The ", as the & indicates the start
of a new query parameter.

Another solution would be to urlencode the error message before passing
it as a parameter. Maybe we should do that anyway, as this solution
still suffers from being unable to cross of a movie like "Me, Myself &
Irene". Maybe we wanted to introduce that type of escaping later though?

In any case, it's a better practice to do html-escaping immediately
before putting the variable in HTML.